### PR TITLE
Remove MassTransit project packing step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,9 +60,6 @@ jobs:
     - name: Pack the Abstractions project
       run: dotnet pack --configuration ${CONFIGURATION} --output ./output "./src/NForza.Cyrus.Abstractions/NForza.Cyrus.Abstractions.csproj" /p:PackageVersion=${{ env.PACKAGE_VERSION }}
 
-    - name: Pack the MassTransit project
-      run: dotnet pack --configuration ${CONFIGURATION} --output ./output "./src/NForza.Cyrus.MassTransit/NForza.Cyrus.MassTransit.csproj" /p:PackageVersion=${{ env.PACKAGE_VERSION }}
-
     - name: Pack the Templating project
       run: dotnet pack --configuration ${CONFIGURATION} --output ./output "./src/NForza.Cyrus.Templating/NForza.Cyrus.Templating.csproj" /p:PackageVersion=${{ env.PACKAGE_VERSION }}
 


### PR DESCRIPTION
Removed the step to pack the MassTransit project from the workflow.